### PR TITLE
Add heroku deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: SERVER_PORT=${PORT} java $JAVA_OPTS -Dspring.data.mongodb.uri=${MONGODB_URI} -jar target/session_service*.jar

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 # session-service
 
 RESTful API to cBioPortal/cbioportal sessions in MongoDB.  

--- a/app.json
+++ b/app.json
@@ -1,0 +1,33 @@
+{
+  "name": "cbioportal-session-service",
+  "description":"The cBioPortal for Cancer Genomics provides visualization, analysis and download of large-scale cancer genomics data sets.",
+  "repository":"https://github.com/cbioportal/session-service",
+  "logo":"http://www.cbioportal.org/images/cbioportal_logo.png",
+  "keywords": [
+    "java",
+    "tomcat",
+    "javascript",
+    "cancer",
+    "genomics"
+  ],
+  "env": {
+    "JAVA_OPTS": {
+      "description":"options for jvm",
+      "value": "-Xmx300m -Xms300m -XX:+UseCompressedOops"
+    },
+    "MAVEN_CUSTOM_OPTS": {
+        "description":"set heroku profile for mvn",
+        "value":"-DskipTests -Dpackaging.type=jar"
+    }
+  },
+  "buildpacks": [
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-java"
+    }
+  ],
+  "addons" : [
+    {
+      "plan": "mongolab:sandbox"
+    }
+  ]
+}


### PR DESCRIPTION
Add heroku deploy option by adding an `app.json`. External mlab mongodb is used (an addon from heroku).