### PR TITLE
Add basic authentication

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+**/*docker-info.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM openjdk:8-jre
+COPY target/*.jar /app.war
+CMD /usr/bin/java ${JAVA_OPTS} -jar /app.war

--- a/README.md
+++ b/README.md
@@ -52,13 +52,24 @@ spring.data.mongodb.port=27017
 ```
 
 To have a context root that is not "/", add to the properties file:
+
 ```
 server.contextPath=/session_service
-server.port=8080
+server.port=8080 # change this if u want to use a different port
 ```
 
-* Assumes you want to run the server on port 8080.  This can be overridden by
-setting the process's SERVER_PORT environment variable.
+One can use session-service with or without basic authentication. It's
+disabled by default. To enable basic authentication set:
+
+```
+security.basic.enabled=true
+security.user.name=user
+security.user.password=pass
+```
+
+By default the server runs on port 8080. This can be overridden by setting the
+process's SERVER_PORT environment variable.
+
 ```
 session-service$ export set SERVER_PORT=8090; mvn package -Dpackaging.type=jar && java -Dspring.data.mongodb.uri=mongodb://localhost:27017/session-service -jar target/session_service-0.1.0.jar
 ```
@@ -66,6 +77,12 @@ session-service$ export set SERVER_PORT=8090; mvn package -Dpackaging.type=jar &
 ## API
 
 Swagger documentation will be found here: http://[url]:[port]/swagger-ui.html e.g. http://localhost:8090/swagger-ui.html
+
+If basic auth is enabled note that one should pass the username password to access these endpoints e.g. with curl:
+
+```
+curl --user user:pass
+```
 
 ### Create
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.3.2.RELEASE</version>
+        <version>1.3.5.RELEASE</version>
     </parent>
 
     <profiles>
@@ -53,7 +53,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-mongodb</artifactId>
-            <version>1.3.3.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
@@ -68,12 +71,12 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
-            <version>2.4.0</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
-            <version>2.4.0</version>
+            <version>2.8.0</version>
         </dependency>
     </dependencies>
 
@@ -94,6 +97,27 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+              <groupId>com.spotify</groupId>
+              <artifactId>dockerfile-maven-plugin</artifactId>
+              <version>1.4.8</version>
+              <executions>
+                <execution>
+                  <id>default</id>
+                  <goals>
+                    <goal>build</goal>
+                    <goal>push</goal>
+                  </goals>
+                </execution>
+              </executions>
+              <configuration>
+                <repository>cbioportal/session-service</repository>
+                <tag>${project.version}</tag>
+                <buildArgs>
+                  <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+                </buildArgs>
+              </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/org/cbioportal/session_service/swagger/SwaggerConfig.java
+++ b/src/main/java/org/cbioportal/session_service/swagger/SwaggerConfig.java
@@ -33,6 +33,11 @@
 package org.cbioportal.session_service.swagger;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 
 import springfox.documentation.swagger2.annotations.EnableSwagger2;

--- a/src/main/java/org/cbioportal/session_service/web/SessionServiceController.java
+++ b/src/main/java/org/cbioportal/session_service/web/SessionServiceController.java
@@ -38,7 +38,11 @@ import org.cbioportal.session_service.service.SessionService;
 
 import org.springframework.web.bind.annotation.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
 import com.fasterxml.jackson.annotation.JsonView;
 
@@ -51,7 +55,10 @@ import java.io.IOException;
  */
 @RestController // shorthand for @Controller, @ResponseBody
 @RequestMapping(value = "/api/sessions/")
-public class SessionServiceController {
+@EnableWebSecurity
+public class SessionServiceController  extends WebSecurityConfigurerAdapter {
+    @Value("${security.basic.enabled:false}")
+    private boolean securityEnabled;
 
     @Autowired
     private SessionService sessionService;
@@ -118,4 +125,22 @@ public class SessionServiceController {
     @ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "Session not found")
     @ExceptionHandler(SessionNotFoundException.class)
     public void handleSessionNotFound() {}
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        if (securityEnabled) {
+            http
+                .csrf().disable()
+                .authorizeRequests()
+                .anyRequest().authenticated()
+                .and().httpBasic();
+        } else {
+            http
+                .csrf().disable()
+                .authorizeRequests()
+                .antMatchers("/**")
+                .permitAll();
+
+        }
+    }
 }


### PR DESCRIPTION
This enables basic authentication. One user/pass for all endpoints. This would allow us to expose the service publicly if we so wish. 

TODO:
- [x] documentation on how to set credentials w `security.user.name=user` and `security.user.password=pass`
- [x] documentation to disable with property `security.ignored=/**`
(https://stackoverflow.com/questions/36280181/disabling-spring-security-in-spring-boot-app)
- [x] update documentation for calling endpoint with curl, needs user/pass as well