### PR TITLE
Fix slow session service on AWS (main_session)

### DIFF
--- a/src/main/java/org/cbioportal/session_service/domain/internal/SessionRepositoryCustom.java
+++ b/src/main/java/org/cbioportal/session_service/domain/internal/SessionRepositoryCustom.java
@@ -45,6 +45,8 @@ public interface SessionRepositoryCustom {
 
     Session findOneBySourceAndTypeAndData(String source, String type, Object data);
 
+    Session findOneBySourceAndTypeAndChecksum(String source, String type, String checksum);
+
     Session findOneBySourceAndTypeAndId(String source, String type, String id);
 
     List<Session> findBySourceAndType(String source, String type);

--- a/src/main/java/org/cbioportal/session_service/domain/internal/SessionRepositoryImpl.java
+++ b/src/main/java/org/cbioportal/session_service/domain/internal/SessionRepositoryImpl.java
@@ -75,6 +75,11 @@ public class SessionRepositoryImpl implements SessionRepositoryCustom {
         return this.mongoTemplate.findOne(query, Session.class, type);
     }
 
+    public Session findOneBySourceAndTypeAndChecksum(String source, String type, String checksum) {
+        Query query = new Query(Criteria.where("source").is(source).and("type").is(type).and("checksum").is(checksum));
+        return this.mongoTemplate.findOne(query, Session.class, type);
+    }
+
     public Session findOneBySourceAndTypeAndId(String source, String type, String id) {
         return this.mongoTemplate.findOne(
             new Query(Criteria.where("source").is(source).and("type").is(type).and("id").is(id)), 

--- a/src/main/java/org/cbioportal/session_service/service/internal/SessionServiceImpl.java
+++ b/src/main/java/org/cbioportal/session_service/service/internal/SessionServiceImpl.java
@@ -66,9 +66,9 @@ public class SessionServiceImpl implements SessionService {
             session = new Session(source, type, data);
             sessionRepository.saveSession(session);
         } catch (DuplicateKeyException e) {
-            session = sessionRepository.findOneBySourceAndTypeAndData(source,
+            session = sessionRepository.findOneBySourceAndTypeAndChecksum(source,
                 type,
-                session.getData());
+                session.getChecksum());
         } catch (ConstraintViolationException e) {
             throw new SessionInvalidException(buildConstraintViolationExceptionMessage(e));
         } catch (JSONParseException e) {


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/5267. Somehow find with the
data field takes really long on AWS session service running 3.6.6 (5-8s
sometimes longer). On dashi2 (v3.2.12) this wasn't a problem (only takes ~1s
there). By using checksum to search instead of the data field, AWS also takes <1s. There is a unique constraint on source, type and checksum.