### PR TITLE
Add docker-compose file and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@ RESTful API to cBioPortal/cbioportal sessions in MongoDB.
 
 Session information is stored in JSON, so this API generalizes to any JSON objects.
 
+
+## Run with Docker
+```
+docker-compose up
+```
+If you want to rebuild the session service image after having made changes in
+development:
+```
+docker-compose up --build
+```
+Check http://localhost:8080/info to confirm session service is running. It
+should show a version number.
+
+Test whether a session can be created like this:
+
+```
+curl -H "Content-Type: application/json" --user user:pass -X POST http://localhost:8080/api/sessions/test_portal/main_session --data '{"title": "my main portal session", "description": "this is an example"}'
+```
+
+## Run without docker
 ### Requirements
 
 JDK 1.7 or later: http://www.oracle.com/technetwork/java/javase/downloads/index.html

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Session information is stored in JSON, so this API generalizes to any JSON objec
 ```
 docker-compose up
 ```
+You can also run it in detached mode with:
+```
+docker-compose up -d
+```
+In that case, to stop it one runs:
+```
+docker-compose down
+```
 If you want to rebuild the session service image after having made changes in
 development:
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Test whether a session can be created like this:
 curl -H "Content-Type: application/json" --user user:pass -X POST http://localhost:8080/api/sessions/test_portal/main_session --data '{"title": "my main portal session", "description": "this is an example"}'
 ```
 
+The mongo database port is not exposed by default. One can connect to the
+mongo database like this:
+```
+docker exec -it session-service_db_1 mongo mongodb://localhost:27017
+```
+
+
+
 ## Run without docker
 ### Requirements
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,6 @@ services:
     # this makes mongo use smaller default size limits:
     # https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-smallfiles
     command: --smallfiles
+    # uncomment this to expose the db port on localhost
+    # ports:
+    #   - "27017:27017"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3"
+services:
+  web:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      - JAVA_OPTS=-Dspring.data.mongodb.uri=mongodb://db:27017/session-service
+      # with user/pass enabled:
+      # - JAVA_OPTS=-Dspring.data.mongodb.uri=mongodb://db:27017/session-service -Dsecurity.basic.enabled=true -Dsecurity.user.name=user -Dsecurity.user.password=pass
+    links:
+      - db
+    depends_on:
+      - db
+  db:
+    image: mongo:3.6.6
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,6 @@ services:
   db:
     image: mongo:3.6.6
     restart: always
+    # this makes mongo use smaller default size limits:
+    # https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-smallfiles
+    command: --smallfiles


### PR DESCRIPTION
The docker compose file makes it a little easier to test the session service in isolation