### PR TITLE
Add new session types

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ curl --user user:pass
 | group | similar to virtual study except its used in comparison page |
 | comparison_session | represent comparison page query |
 | settings | represent cbio page settings. page type is identified by a field `page` in it |
+| custom_data | holds study-view page custom charts data |
+| genomic_chart | represents genomic chart added by user in study-view page |
 
 #### POST http://localhost:8080/api/sessions/{source}/{type}/
 Creates a session.  Returns status 200 and the session id in response body
@@ -160,7 +162,7 @@ with something like the following in the body:
   "status": 400,
   "error": "Bad Request",
   "exception": "org.springframework.web.method.annotation.MethodArgumentTypeMismatchException",
-  "message": "valid types are: main_session, virtual_study, group, comparison_session",
+  "message": "valid types are: main_session, virtual_study, group, comparison_session, custom_data, genomic_chart",
   "path": "/api/sessions/msk_portal/invalid_type/"
 }
 ```

--- a/src/main/java/org/cbioportal/session_service/domain/SessionType.java
+++ b/src/main/java/org/cbioportal/session_service/domain/SessionType.java
@@ -5,5 +5,7 @@ public enum SessionType {
 	virtual_study,
 	group,
 	comparison_session,
-	settings;
+	settings,
+	custom_data,
+	genomic_chart;
 }


### PR DESCRIPTION
Adds new session types
1. `custom_data` -> required for saving user custom charts. Model of the object that would be saved for this session type
```
{
    "attribute": {
        "attributeId": "string",
        "datatype": "string",
        "description": "string",
        "displayName": "string",
        "patientAttribute": "boolean"
    },
    "data": [{
        "patientId": "string",
        "sampleId": "string",
        "studyId": "string",
        "value": "string"
    }],
    "origin": ["string"],  --> study ids
    "owner": "string",
    "created": "string",
    "users": ["string"]
}
```

2.  `genomic_chart` -> required to save user genomic charts. 
Model of the the saved object
```
{
	"hugoGeneSymbol": "string",
	"profileType": "string",
	"disableLogScale": "boolean",
	"origin": ["string"],
	"owner": "string",
	"created": "string",
	"users": ["string"]
}
```

Note: model might change in the future