### PR TITLE
Set version for slf4j and bindings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,14 @@
   <artifactId>session_service</artifactId>
   <version>0.4.0</version>
   <packaging>${packaging.type}</packaging>
+
   <!-- inherit defaults from spring boot -->
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
     <version>2.3.3.RELEASE</version>
   </parent>
+
   <profiles>
     <profile>
       <id>war</id>
@@ -32,6 +34,7 @@
       </properties>
     </profile>
   </profiles>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -85,10 +88,34 @@
       <artifactId>hibernate-validator</artifactId>
       <version>6.0.13.Final</version>
     </dependency>
+    <!-- slf4j -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.5</version>
+    </dependency>
   </dependencies>
+
   <properties>
     <java.version>1.8</java.version>
+    <slf4j.version>1.7.30</slf4j.version>
   </properties>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
PR explicitly sets the version of slf4j and its bindings to help prevent errors caused. by mismatched versions brought in by related dependencies. 

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>