### PR TITLE
Support custom gene list type

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ curl --user user:pass
 | settings | represent cbio page settings. page type is identified by a field `page` in it |
 | custom_data | holds study-view page custom charts data |
 | genomic_chart | represents genomic chart added by user in study-view page |
+| custom_gene_list | represents custom gene list added by user in query page |
 
 #### POST http://localhost:8080/api/sessions/{source}/{type}/
 Creates a session.  Returns status 200 and the session id in response body

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <url>https://github.com/cBioPortal/session-service/</url>
   <groupId>org.cbioportal.session_service</groupId>
   <artifactId>session_service</artifactId>
-  <version>0.4.1</version>
+  <version>0.5.0</version>
   <packaging>${packaging.type}</packaging>
   <!-- inherit defaults from spring boot -->
   <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <url>https://github.com/cBioPortal/session-service/</url>
   <groupId>org.cbioportal.session_service</groupId>
   <artifactId>session_service</artifactId>
-  <version>0.4.0</version>
+  <version>0.4.1</version>
   <packaging>${packaging.type}</packaging>
   <!-- inherit defaults from spring boot -->
   <parent>

--- a/src/main/java/org/cbioportal/session_service/domain/SessionType.java
+++ b/src/main/java/org/cbioportal/session_service/domain/SessionType.java
@@ -7,5 +7,6 @@ public enum SessionType {
 	comparison_session,
 	settings,
 	custom_data,
-	genomic_chart;
+	genomic_chart,
+	custom_gene_list;
 }


### PR DESCRIPTION
Changes in this pr:

- Add new type: `custom_gene_list`
- Update documentation
- Update session-service version to from `0.4.0` to `0.5.0` (backwards incompatible)