### PR TITLE
Replace BasicDBObject to Document to support de-serialize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ bin/
 node_modules
 /target/
 .DS_Store
+.idea*
+*.iml

--- a/src/main/java/org/cbioportal/session_service/domain/Session.java
+++ b/src/main/java/org/cbioportal/session_service/domain/Session.java
@@ -35,9 +35,10 @@ package org.cbioportal.session_service.domain;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonView;
-import com.mongodb.BasicDBObject;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+
+import org.bson.Document;
 import org.springframework.data.annotation.Id;
 import org.springframework.util.DigestUtils;
 
@@ -70,12 +71,11 @@ public class Session {
 
     public void setData(Object data) {
         if(data instanceof String) {
-            this.data = BasicDBObject.parse((String)data);
+            this.data = Document.parse((String)data);
         } else {
             this.data = data;
         }
-        // JSON.serialize it so that formatting is the same if we test later
-        this.checksum = DigestUtils.md5DigestAsHex(((BasicDBObject)this.data).toString().getBytes());
+        this.checksum = DigestUtils.md5DigestAsHex(this.data.toString().getBytes());
     }
 
     @JsonView(Session.Views.Full.class)


### PR DESCRIPTION
With recent updates to spring boot and mongdb dependency libraries there have beens some issues when using session-service as a code dependency in cbioportal.

**Problem**
de-serializing `BasicDBObject` isn't straightforward with change from `JSON` to `BasicDBObject` at https://github.com/cBioPortal/session-service/pull/36/files#diff-e01964c6f48d027b0eb55a2545f4f11d8e521fc335ebfdfc4681c909a3257e65R78. This is throwing exception in cbioportal.

```
com.fasterxml.jackson.databind.JsonMappingException: class java.util.LinkedHashMap cannot be cast to class com.mongodb.BasicDBObject (java.util.LinkedHashMap is in module java.base of loader 'bootstrap'; com.mongodb.BasicDBObject is in unnamed module of loader 
```
**Solution**
Use newest client object(`Document`) instead of `BasicDBObject`.