### PR TITLE
Replace hardcoded version string w/ version from manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
               <goal>jar</goal>
             </goals>
             <configuration>
+              <archive>
+                <manifest>
+                  <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                  <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                </manifest>
+              </archive>
               <classifier>model</classifier>
               <includes>
                 <include>org/cbioportal/session_service/domain/**</include>

--- a/src/main/java/org/cbioportal/session_service/web/InfoController.java
+++ b/src/main/java/org/cbioportal/session_service/web/InfoController.java
@@ -8,11 +8,9 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping(value = "/info")
 public class InfoController {
-    // This is supposed to in sync with the pom version
-    String version = "0.1.0";
 
     public String getVersion() {
-        return version;
+        return getClass().getPackage().getImplementationVersion();
     }
 
     @RequestMapping(method = RequestMethod.GET, value = "")


### PR DESCRIPTION
- The info controller was hard coded to return 0.1.0
- Maven doesn't put the version information by default
  - Tell it to into the pom
- Then just get that version info in the controller.