### PR TITLE
Move SessionRepository classes to repository package

### DIFF
--- a/src/main/java/org/cbioportal/session_service/domain/SessionRepository.java
+++ b/src/main/java/org/cbioportal/session_service/domain/SessionRepository.java
@@ -32,10 +32,9 @@
 
 package org.cbioportal.session_service.domain;
 
-import org.cbioportal.session_service.domain.internal.SessionRepositoryCustom;
+import org.cbioportal.session_service.repository.SessionRepositoryCustom;
  
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.mongodb.repository.Query;
 
 /**
  * @author Manda Wilson 

--- a/src/main/java/org/cbioportal/session_service/repository/SessionRepositoryCustom.java
+++ b/src/main/java/org/cbioportal/session_service/repository/SessionRepositoryCustom.java
@@ -30,7 +30,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package org.cbioportal.session_service.domain.internal;
+package org.cbioportal.session_service.repository;
 
 import org.cbioportal.session_service.domain.Session;
 import org.cbioportal.session_service.domain.SessionType;

--- a/src/main/java/org/cbioportal/session_service/repository/SessionRepositoryImpl.java
+++ b/src/main/java/org/cbioportal/session_service/repository/SessionRepositoryImpl.java
@@ -30,7 +30,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package org.cbioportal.session_service.domain.internal;
+package org.cbioportal.session_service.repository;
 
 import org.bson.Document;
 import org.cbioportal.session_service.domain.Session;


### PR DESCRIPTION
Fixes #44

Removes SessionRepositoryImpl.java from session-service dependency jar, so that application context problems are avoided.

Edit:
The application context problem is caused by SessionRepositoryImpl.java requiring a MongoTemplate bean. The MongoTemplate bean is created when the application is configured to access a mongoDB instance. Because of this projects that merely require the domain information of session-service, are required to somehow to configure a MongoDB connection in order to create a MongoTemplate bean. The migration of SessionRepositoryImpl.java to a different package will avoid exporting this class in the domain/model jar so that the dependency will no longer require the application to create a MongoTemplate bean.