### PR TITLE
Revert "Move SessionRepository classes to repository package"

### DIFF
--- a/src/main/java/org/cbioportal/session_service/domain/SessionRepository.java
+++ b/src/main/java/org/cbioportal/session_service/domain/SessionRepository.java
@@ -32,9 +32,10 @@
 
 package org.cbioportal.session_service.domain;
 
-import org.cbioportal.session_service.repository.SessionRepositoryCustom;
+import org.cbioportal.session_service.domain.internal.SessionRepositoryCustom;
  
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 /**
  * @author Manda Wilson 

--- a/src/main/java/org/cbioportal/session_service/domain/internal/SessionRepositoryCustom.java
+++ b/src/main/java/org/cbioportal/session_service/domain/internal/SessionRepositoryCustom.java
@@ -30,7 +30,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package org.cbioportal.session_service.repository;
+package org.cbioportal.session_service.domain.internal;
 
 import org.cbioportal.session_service.domain.Session;
 import org.cbioportal.session_service.domain.SessionType;

--- a/src/main/java/org/cbioportal/session_service/domain/internal/SessionRepositoryImpl.java
+++ b/src/main/java/org/cbioportal/session_service/domain/internal/SessionRepositoryImpl.java
@@ -30,7 +30,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package org.cbioportal.session_service.repository;
+package org.cbioportal.session_service.domain.internal;
 
 import org.bson.Document;
 import org.cbioportal.session_service.domain.Session;


### PR DESCRIPTION
Reverts cBioPortal/session-service#45. Fixes #49, but re-introduces https://github.com/cBioPortal/session-service/issues/44

For some reason this change causes the following error https://github.com/cBioPortal/session-service/issues/49 for both @dippindots and me. Proposing to revert these changes for now