### PR TITLE
Adding Sentry into session service

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ process's SERVER_PORT environment variable.
 session-service$ export set SERVER_PORT=8090; mvn package -Dpackaging.type=jar && java -Dspring.data.mongodb.uri=mongodb://localhost:27017/session-service -jar target/session_service-0.1.0.jar
 ```
 
+## Sentry support
+
+Sentry is already included as a dependency of this project, one can add the following this [Sentry official documentation](https://docs.sentry.io/platforms/java/guides/spring-boot/configuration/#setting-the-dsn) to enable sentry.
+For example, for Run without docker, add the following when starting the server:
+```
+-Dsentry.dsn=https://examplePublicKey@o0.ingest.sentry.io/0
+```
+And example command for Run with docker also included in the docker-compoase.yaml file, please refer that command to enable sentry.
+
 ## API
 
 Swagger documentation will be found here: http://[url]:[port]/swagger-ui.html e.g. http://localhost:8090/swagger-ui.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - "8080:8080"
     environment:
       - JAVA_OPTS=-Dspring.data.mongodb.uri=mongodb://db:27017/session-service
+      # with sentry logging enabled (replace SENTRY_DSN with yours sentry dsn, one can find it in the SDK setup section in sentry's setting):
+      # - JAVA_OPTS=-Dspring.data.mongodb.uri=mongodb://db:27017/session-service -Dsentry.dsn=SENTRY_DSN
       # with user/pass enabled:
       # - JAVA_OPTS=-Dspring.data.mongodb.uri=mongodb://db:27017/session-service -Dsecurity.basic.enabled=true -Dspring.security.user.name=user -Dspring.security.user.password=pass
     links:

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,11 @@
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.sentry</groupId>
+      <artifactId>sentry-spring</artifactId>
+      <version>6.25.0</version>
+    </dependency>
   </dependencies>
   <properties>
     <java.version>1.8</java.version>


### PR DESCRIPTION
Fix https://github.com/cBioPortal/cbioportal/issues/10226
Adding sentry as a dependency for session service

See successful test logs here: 
https://memorial-sloan-kettering.sentry.io/projects/session-service/?project=1255638&statsPeriod=7d