### PR TITLE
Make it possible to create session service documents with custom IDs

### DIFF
--- a/src/main/java/org/cbioportal/session_service/domain/Session.java
+++ b/src/main/java/org/cbioportal/session_service/domain/Session.java
@@ -64,6 +64,9 @@ public class Session {
     public String getId() {
         return id;
     }
+    public void setId(String id) {
+        this.id = id;
+    }
 
     public String getChecksum() {
         return checksum;

--- a/src/main/java/org/cbioportal/session_service/domain/internal/SessionRepositoryCustom.java
+++ b/src/main/java/org/cbioportal/session_service/domain/internal/SessionRepositoryCustom.java
@@ -44,6 +44,8 @@ public interface SessionRepositoryCustom {
 
     void saveSession(Session session);
 
+    Session createNewSession(Session session);
+
     Session findOneBySourceAndTypeAndData(String source, SessionType type, Object data);
 
     Session findOneBySourceAndTypeAndChecksum(String source, SessionType type, String checksum);

--- a/src/main/java/org/cbioportal/session_service/domain/internal/SessionRepositoryCustom.java
+++ b/src/main/java/org/cbioportal/session_service/domain/internal/SessionRepositoryCustom.java
@@ -41,10 +41,30 @@ import java.util.List;
  * @author Manda Wilson 
  */
 public interface SessionRepositoryCustom {
+    /**
+     * Inserts or updates the given {@link Session} in the corresponding MongoDB collection.
+     * <p>
+     * If the collection for the session type does not exist, it will be created along with
+     * appropriate compound indexes on the fields: <code>source</code>, <code>type</code>, and <code>checksum</code>.
+     * <p>
+     * If a session with the same identifier already exists, it will be updated (replaced).
+     *
+     * @param session the {@link Session} object to be saved or updated in the database.
+     */
+    void upsertSession(Session session);
 
-    void saveSession(Session session);
-
-    Session createNewSession(Session session);
+    /**
+     * Inserts a new {@link Session} into the corresponding MongoDB collection.
+     * <p>
+     * If the collection for the session type does not exist, it will be created along with
+     * appropriate compound indexes on the fields: <code>source</code>, <code>type</code>, and <code>checksum</code>.
+     * <p>
+     * This method will throw an exception if a session with the same identifier already exists.
+     *
+     * @param session the {@link Session} object to be inserted into the database.
+     * @return the inserted {@link Session} instance.
+     */
+    Session insertSession(Session session);
 
     Session findOneBySourceAndTypeAndData(String source, SessionType type, Object data);
 

--- a/src/main/java/org/cbioportal/session_service/domain/internal/SessionRepositoryImpl.java
+++ b/src/main/java/org/cbioportal/session_service/domain/internal/SessionRepositoryImpl.java
@@ -57,7 +57,7 @@ public class SessionRepositoryImpl implements SessionRepositoryCustom {
     private MongoTemplate mongoTemplate;
     
     @Override
-    public void saveSession(Session session) {
+    public void upsertSession(Session session) {
         ensureIndexes(session);
         this.mongoTemplate.save(session, session.getType().toString());
     }
@@ -75,7 +75,7 @@ public class SessionRepositoryImpl implements SessionRepositoryCustom {
     }
 
     @Override
-    public Session createNewSession(Session session) {
+    public Session insertSession(Session session) {
         ensureIndexes(session);
         return this.mongoTemplate.insert(session, session.getType().toString());
     }

--- a/src/main/java/org/cbioportal/session_service/service/SessionService.java
+++ b/src/main/java/org/cbioportal/session_service/service/SessionService.java
@@ -42,8 +42,8 @@ import java.util.List;
  * @author Manda Wilson 
  */
 public interface SessionService {
-    Session addSession(String id, String source, SessionType type, String data) throws SessionInvalidException;
     Session addSession(String source, SessionType type, String data) throws SessionInvalidException;
+    Session createNewSession(String id, String source, SessionType type, String data) throws SessionInvalidException;
     List<Session> getSessions(String source, SessionType type);
     List<Session> getSessionsByQuery(String source, SessionType type, String query);
     Session getSession(String source, SessionType type, String id) throws SessionNotFoundException;

--- a/src/main/java/org/cbioportal/session_service/service/SessionService.java
+++ b/src/main/java/org/cbioportal/session_service/service/SessionService.java
@@ -42,6 +42,7 @@ import java.util.List;
  * @author Manda Wilson 
  */
 public interface SessionService {
+    Session addSession(String id, String source, SessionType type, String data) throws SessionInvalidException;
     Session addSession(String source, SessionType type, String data) throws SessionInvalidException;
     List<Session> getSessions(String source, SessionType type);
     List<Session> getSessionsByQuery(String source, SessionType type, String query);

--- a/src/main/java/org/cbioportal/session_service/service/exception/SessionAlreadyExists.java
+++ b/src/main/java/org/cbioportal/session_service/service/exception/SessionAlreadyExists.java
@@ -1,0 +1,11 @@
+package org.cbioportal.session_service.service.exception;
+
+/**
+ * Exception thrown when a session with the specified ID already exists in the repository.
+ * This is typically used to prevent undesired overwriting of existing sessions.
+ */
+public class SessionAlreadyExists extends RuntimeException {
+    public SessionAlreadyExists(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/cbioportal/session_service/service/internal/SessionServiceImpl.java
+++ b/src/main/java/org/cbioportal/session_service/service/internal/SessionServiceImpl.java
@@ -57,11 +57,18 @@ public class SessionServiceImpl implements SessionService {
     @Autowired
     private SessionRepository sessionRepository;
 
+    /**
+     * Adds a session to the repository.
+     * @param id the unique identifier for the session, can be null (automatically generated)
+     */
     @Override
-    public Session addSession(String source, SessionType type, String data) throws SessionInvalidException {
+    public Session addSession(String id, String source, SessionType type, String data) throws SessionInvalidException {
         Session session = null;
         try {
             session = new Session();
+            if (id != null) {
+                session.setId(id);
+            }
             session.setSource(source);
             session.setType(type);
             session.setData(data);
@@ -79,6 +86,11 @@ public class SessionServiceImpl implements SessionService {
             throw new SessionInvalidException(e.getMessage());
         }
         return session;
+    }
+
+    @Override
+    public Session addSession(String source, SessionType type, String data) throws SessionInvalidException {
+        return addSession(null, source, type, data);
     }
 
     @Override

--- a/src/main/java/org/cbioportal/session_service/service/internal/SessionServiceImpl.java
+++ b/src/main/java/org/cbioportal/session_service/service/internal/SessionServiceImpl.java
@@ -100,7 +100,7 @@ public class SessionServiceImpl implements SessionService {
      * This method is different from {@link #addSession(String, SessionType, String)} in the following ways:
      *             - it does not look up and return an existing session with identical data (detected by checksum). In such scenario this method would just throw SessionAlreadyExistsException.
      *               - Note (historical context): This behavior is not the primary intent of the method, but rather a side effect of the unique index on the source, type, and checksum fields, which prevents duplicate sessions (see {@link #addSession(String, SessionType, String)}).
-     *               - Although this constraint wasn't by design, it might be useful, particularly for published virtual studies, ensuring that no two are identical.
+     *               - Although this constraint wasn't by design, it might be useful, particularly for published virtual studies, ensuring that no two are identical. Which is unlikely to happen, because the data often contains a timestamp.
      *             - it does not overwrite an existing session with the same id. In such scenario this method would throw SessionAlreadyExistsException. Only really possible when custom id is provided.
      */
     @Override

--- a/src/main/java/org/cbioportal/session_service/service/internal/SessionServiceImpl.java
+++ b/src/main/java/org/cbioportal/session_service/service/internal/SessionServiceImpl.java
@@ -74,7 +74,7 @@ public class SessionServiceImpl implements SessionService {
             session.setType(type);
             session.setData(data);
 
-            sessionRepository.saveSession(session);
+            sessionRepository.upsertSession(session);
         } catch (DuplicateKeyException e) {
             session = sessionRepository.findOneBySourceAndTypeAndChecksum(source,
                     type,
@@ -114,7 +114,7 @@ public class SessionServiceImpl implements SessionService {
             session.setType(type);
             session.setData(data);
 
-            sessionRepository.createNewSession(session);
+            sessionRepository.insertSession(session);
             return session;
         } catch (DuplicateKeyException e) {
             throw new SessionAlreadyExists(e.getMessage());
@@ -156,7 +156,7 @@ public class SessionServiceImpl implements SessionService {
         if (savedSession != null) {
             try {
                 savedSession.setData(data);
-                sessionRepository.saveSession(savedSession);
+                sessionRepository.upsertSession(savedSession);
             } catch (ConstraintViolationException e) {
                 throw new SessionInvalidException(buildConstraintViolationExceptionMessage(e));
             } catch (JsonParseException e) {

--- a/src/main/java/org/cbioportal/session_service/service/internal/SessionServiceImpl.java
+++ b/src/main/java/org/cbioportal/session_service/service/internal/SessionServiceImpl.java
@@ -59,16 +59,17 @@ public class SessionServiceImpl implements SessionService {
 
     /**
      * Adds a session to the repository.
-     * @param id the unique identifier for the session, can be null (automatically generated)
+     * @param source - catalog of the session
+     * @param type - type of the session, e.g. "virtual_study", "settings", etc.
+     * @param data - actual payload of the session
+     * @return the session that was added, or an existing session with the same source, type and data (detected by checksum)
+     * @throws SessionInvalidException if the session data is invalid, e.g. does not conform to the schema
      */
     @Override
-    public Session addSession(String id, String source, SessionType type, String data) throws SessionInvalidException {
+    public Session addSession(String source, SessionType type, String data) throws SessionInvalidException {
         Session session = null;
         try {
             session = new Session();
-            if (id != null) {
-                session.setId(id);
-            }
             session.setSource(source);
             session.setType(type);
             session.setData(data);
@@ -76,8 +77,8 @@ public class SessionServiceImpl implements SessionService {
             sessionRepository.saveSession(session);
         } catch (DuplicateKeyException e) {
             session = sessionRepository.findOneBySourceAndTypeAndChecksum(source,
-                type,
-                session.getChecksum());
+                    type,
+                    session.getChecksum());
         } catch (ConstraintViolationException e) {
             throw new SessionInvalidException(buildConstraintViolationExceptionMessage(e));
         } catch (JsonParseException e) {
@@ -88,9 +89,38 @@ public class SessionServiceImpl implements SessionService {
         return session;
     }
 
+    /**
+     * Creates a new session in the repository.
+     * @param id the custom unique identifier for the session, can be null (automatically generated)
+     * @param source - catalog of the session
+     * @param type - type of the session, e.g. "virtual_study"
+     * @param data - actual payload of the session
+     * @throws SessionAlreadyExists if a session with the same id or source, type and data already exists
+     * @throws SessionInvalidException if the session data is invalid, e.g. does not conform to the schema
+     * This method is different from {@link #addSession(String, SessionType, String)} in the following ways:
+     *             - it does not look up and return an existing session with identical data (detected by checksum). In such scenario this method would just throw SessionAlreadyExistsException.
+     *               - Note (historical context): This behavior is not the primary intent of the method, but rather a side effect of the unique index on the source, type, and checksum fields, which prevents duplicate sessions (see {@link #addSession(String, SessionType, String)}).
+     *               - Although this constraint wasn't by design, it might be useful, particularly for published virtual studies, ensuring that no two are identical.
+     *             - it does not overwrite an existing session with the same id. In such scenario this method would throw SessionAlreadyExistsException. Only really possible when custom id is provided.
+     */
     @Override
-    public Session addSession(String source, SessionType type, String data) throws SessionInvalidException {
-        return addSession(null, source, type, data);
+    public Session createNewSession(String id, String source, SessionType type, String data) throws SessionInvalidException {
+        try {
+            Session session = new Session();
+            if (id != null) {
+                session.setId(id);
+            }
+            session.setSource(source);
+            session.setType(type);
+            session.setData(data);
+
+            sessionRepository.createNewSession(session);
+            return session;
+        } catch (DuplicateKeyException e) {
+            throw new SessionAlreadyExists(e.getMessage());
+        } catch (RuntimeException e) {
+            throw new SessionInvalidException(e.getMessage());
+        }
     }
 
     @Override

--- a/src/main/java/org/cbioportal/session_service/web/SessionServiceController.java
+++ b/src/main/java/org/cbioportal/session_service/web/SessionServiceController.java
@@ -81,11 +81,11 @@ public class SessionServiceController {
 
     @RequestMapping(method = RequestMethod.POST, value="/{source}/{type}/{id}")
     @JsonView(Session.Views.IdOnly.class)
-    public Session addSession(@PathVariable String source,
+    public Session createNewSession(@PathVariable String source,
                               @PathVariable SessionType type,
                               @PathVariable String id,
                               @RequestBody String data) {
-        return sessionService.addSession(id, source, type, data);
+        return sessionService.createNewSession(id, source, type, data);
     }
 
     @RequestMapping(method = RequestMethod.GET, value="/{source}/{type}")
@@ -152,7 +152,11 @@ public class SessionServiceController {
     @ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "Session not found")
     @ExceptionHandler(SessionNotFoundException.class)
     public void handleSessionNotFound() {}
-    
+
+    @ResponseStatus(code = HttpStatus.CONFLICT, reason = "Session already exists")
+    @ExceptionHandler(SessionAlreadyExists.class)
+    public void handleSessionAlreadyExists() {}
+
     @ExceptionHandler
     public void handleSessionTypeInvalid(MethodArgumentTypeMismatchException e, HttpServletResponse response)
             throws IOException {

--- a/src/main/java/org/cbioportal/session_service/web/SessionServiceController.java
+++ b/src/main/java/org/cbioportal/session_service/web/SessionServiceController.java
@@ -79,6 +79,15 @@ public class SessionServiceController {
         return sessionService.addSession(source, type, data);
     }
 
+    @RequestMapping(method = RequestMethod.POST, value="/{source}/{type}/{id}")
+    @JsonView(Session.Views.IdOnly.class)
+    public Session addSession(@PathVariable String source,
+                              @PathVariable SessionType type,
+                              @PathVariable String id,
+                              @RequestBody String data) {
+        return sessionService.addSession(id, source, type, data);
+    }
+
     @RequestMapping(method = RequestMethod.GET, value="/{source}/{type}")
     @JsonView(Session.Views.Full.class)
     public Iterable<Session> getSessions(@PathVariable String source, 

--- a/src/test/java/org/cbioportal/session_service/SessionServiceTest.java
+++ b/src/test/java/org/cbioportal/session_service/SessionServiceTest.java
@@ -40,7 +40,6 @@ import java.util.regex.Pattern;
 import static org.hamcrest.Matchers.*;
 import org.junit.*;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -157,10 +156,10 @@ public class SessionServiceTest {
         assertThat(createNewSessionResponse.getStatusCode(), equalTo(HttpStatus.OK));
 
         String data2 = "\"portal-session\":\"altered session information\"";
-        ResponseEntity<String> createDuplicateByIdResonse = createNewSession("msk_portal", "main_session", customVsId, data2);
+        ResponseEntity<String> createDuplicateByIdResponse = createNewSession("msk_portal", "main_session", customVsId, data2);
 
         // test that the status was 409
-        assertThat(createDuplicateByIdResonse.getStatusCode(), equalTo(HttpStatus.CONFLICT));
+        assertThat(createDuplicateByIdResponse.getStatusCode(), equalTo(HttpStatus.CONFLICT));
 
         // the content should not change during the conflict
         ResponseEntity<String> fetchNewSessionResponse = template.getForEntity(base.toString() + "msk_portal/main_session/" + customVsId, String.class);

--- a/src/test/java/org/cbioportal/session_service/SessionServiceTest.java
+++ b/src/test/java/org/cbioportal/session_service/SessionServiceTest.java
@@ -40,6 +40,8 @@ import java.util.regex.Pattern;
 import static org.hamcrest.Matchers.*;
 import org.junit.*;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -125,23 +127,68 @@ public class SessionServiceTest {
     }
 
     @Test
-    public void addSessionWithCustomId() throws Exception {
+    public void createNewSessionWithCustomId() throws Exception {
         // add data
         String data = "\"portal-session\":\"my session information\"";
-        ResponseEntity<String> response = addData("msk_portal", "main_session", "custom_vs_id", data);
+        ResponseEntity<String> createNewSessionResponse = createNewSession("msk_portal", "main_session", "custom_vs_id", data);
 
         // test that the status was 200
-        assertThat(response.getStatusCode(), equalTo(HttpStatus.OK));
+        assertThat(createNewSessionResponse.getStatusCode(), equalTo(HttpStatus.OK));
 
         // get id
-        List<String> ids = parseIds(response.getBody());
+        List<String> ids = parseIds(createNewSessionResponse.getBody());
         assertThat(ids.size(), equalTo(1));
         String id = ids.get(0);
         assertThat(id, equalTo("custom_vs_id"));
 
         // get record
-        response = template.getForEntity(base.toString() + "msk_portal/main_session/" + id, String.class);
-        assertThat(expectedResponse(response.getBody(), "msk_portal", "main_session", data), equalTo(true));
+        ResponseEntity<String> fetchNewSessionResponse = template.getForEntity(base.toString() + "msk_portal/main_session/" + id, String.class);
+        assertThat(expectedResponse(fetchNewSessionResponse.getBody(), "msk_portal", "main_session", data), equalTo(true));
+    }
+
+    @Test
+    public void createNewSessionWithExistingId() throws Exception {
+        String customVsId = "custom_vs_id";
+        // add data
+        String data1 = "\"portal-session\":\"my session information\"";
+        ResponseEntity<String> createNewSessionResponse = createNewSession("msk_portal", "main_session", customVsId, data1);
+
+        // test that the status was 200
+        assertThat(createNewSessionResponse.getStatusCode(), equalTo(HttpStatus.OK));
+
+        String data2 = "\"portal-session\":\"altered session information\"";
+        ResponseEntity<String> createDuplicateByIdResonse = createNewSession("msk_portal", "main_session", customVsId, data2);
+
+        // test that the status was 409
+        assertThat(createDuplicateByIdResonse.getStatusCode(), equalTo(HttpStatus.CONFLICT));
+
+        // the content should not change during the conflict
+        ResponseEntity<String> fetchNewSessionResponse = template.getForEntity(base.toString() + "msk_portal/main_session/" + customVsId, String.class);
+        assertThat(expectedResponse(fetchNewSessionResponse.getBody(), "msk_portal", "main_session", data1), equalTo(true));
+    }
+
+    @Test
+    public void createNewSessionWithIdenticalData() throws Exception {
+        // add data
+        String data1 = "\"portal-session\":\"my session information\"";
+        String customVsId1 = "custom_vs_id_1";
+        ResponseEntity<String> createNewSessionResponse = createNewSession("msk_portal", "main_session", customVsId1, data1);
+
+        // test that the status was 200
+        assertThat(createNewSessionResponse.getStatusCode(), equalTo(HttpStatus.OK));
+
+        String customVsId2 = "custom_vs_id_2";
+        ResponseEntity<String> createDuplicateByContentResponse = createNewSession("msk_portal", "main_session", customVsId2, data1);
+
+        // test that the status was 409
+        assertThat(createDuplicateByContentResponse.getStatusCode(), equalTo(HttpStatus.CONFLICT));
+
+        // the content should not change during the conflict
+        ResponseEntity<String> fetchNewSessionResponse = template.getForEntity(base.toString() + "msk_portal/main_session/" + customVsId1, String.class);
+        assertThat(expectedResponse(fetchNewSessionResponse.getBody(), "msk_portal", "main_session", data1), equalTo(true));
+
+        ResponseEntity<String> fetchDuplicateResponse = template.getForEntity(base.toString() + "msk_portal/main_session/" + customVsId2, String.class);
+        assertThat(fetchDuplicateResponse.getStatusCode(), equalTo(HttpStatus.NOT_FOUND));
     }
 
     @Test
@@ -466,13 +513,14 @@ public class SessionServiceTest {
         return new HttpEntity<String>(data, headers);
     }
 
-    private ResponseEntity<String> addData(String source, String type, String id, String data) throws Exception {
+    private ResponseEntity<String> addData(String source, String type, String data) throws Exception {
         HttpEntity<String> entity = prepareData(data);
-        return template.exchange(base.toString() + source + "/" + type + (id == null ? "" : "/" + id), HttpMethod.POST, entity, String.class);
+        return template.exchange(base.toString() + source + "/" + type, HttpMethod.POST, entity, String.class);
     }
 
-    private ResponseEntity<String> addData(String source, String type, String data) throws Exception {
-        return addData(source, type, null, data);
+    private ResponseEntity<String> createNewSession(String source, String type, String id, String data) throws Exception {
+        HttpEntity<String> entity = prepareData(data);
+        return template.exchange(base.toString() + source + "/" + type + "/" + id, HttpMethod.POST, entity, String.class);
     }
 
     /*

--- a/src/test/java/org/cbioportal/session_service/SessionServiceTest.java
+++ b/src/test/java/org/cbioportal/session_service/SessionServiceTest.java
@@ -125,6 +125,26 @@ public class SessionServiceTest {
     }
 
     @Test
+    public void addSessionWithCustomId() throws Exception {
+        // add data
+        String data = "\"portal-session\":\"my session information\"";
+        ResponseEntity<String> response = addData("msk_portal", "main_session", "custom_vs_id", data);
+
+        // test that the status was 200
+        assertThat(response.getStatusCode(), equalTo(HttpStatus.OK));
+
+        // get id
+        List<String> ids = parseIds(response.getBody());
+        assertThat(ids.size(), equalTo(1));
+        String id = ids.get(0);
+        assertThat(id, equalTo("custom_vs_id"));
+
+        // get record
+        response = template.getForEntity(base.toString() + "msk_portal/main_session/" + id, String.class);
+        assertThat(expectedResponse(response.getBody(), "msk_portal", "main_session", data), equalTo(true));
+    }
+
+    @Test
     public void addSessionNoData() throws Exception {
         // add {} actually works TODO decide if it should
         String data = "";
@@ -446,9 +466,13 @@ public class SessionServiceTest {
         return new HttpEntity<String>(data, headers);
     }
 
-    private ResponseEntity<String> addData(String source, String type, String data) throws Exception {
+    private ResponseEntity<String> addData(String source, String type, String id, String data) throws Exception {
         HttpEntity<String> entity = prepareData(data);
-        return template.exchange(base.toString() + source + "/" + type, HttpMethod.POST, entity, String.class);
+        return template.exchange(base.toString() + source + "/" + type + (id == null ? "" : "/" + id), HttpMethod.POST, entity, String.class);
+    }
+
+    private ResponseEntity<String> addData(String source, String type, String data) throws Exception {
+        return addData(source, type, null, data);
     }
 
     /*


### PR DESCRIPTION
To support RFC96 Virtual Study Authorisation Model we need static human readable ids to assign permissions to them

Related PR: https://github.com/cBioPortal/cbioportal/pull/11611
RFC96: https://docs.google.com/document/d/1aLRzLZvz0hzIM3nf2vqnSayEEjiUVOt3mP2xrUhufaU/edit?usp=sharing